### PR TITLE
Fix Build and set ItemGrabMenu.source correctly (Fishbot Compatibility)

### DIFF
--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -720,7 +720,7 @@ public class ModEntry : Mod
 					possibles.Add(390);
 				}
 				possibles.Add(382);
-				Item treasure = ItemRegistry.Create(Game1.random.ChooseFrom(possibles).ToString(), Game1.random.Next(2, 7) * ((!(Game1.random.NextDouble() < 0.05 + (double)(int)who.luckLevel * 0.015)) ? 1 : 2));
+				Item treasure = ItemRegistry.Create(Game1.random.ChooseFrom(possibles).ToString(), Game1.random.Next(2, 7) * ((!(Game1.random.NextDouble() < 0.05 + (double)(int)who.LuckLevel * 0.015)) ? 1 : 2));
 				if (Game1.random.NextDouble() < 0.05 + (double)who.LuckLevel * 0.03)
 				{
 					treasure.Stack *= 2;
@@ -927,7 +927,7 @@ public class ModEntry : Mod
 				treasures.Add(roe);
 			}
 		}
-		if ((int)Game1.player.fishingLevel > 4 && Game1.player.stats.Get("FishingTreasures") > 2 && Game1.random.NextDouble() < 0.02 + ((!Game1.player.mailReceived.Contains("roeBookDropped")) ? ((double)Game1.player.stats.Get("FishingTreasures") * 0.001) : 0.001))
+		if ((int)Game1.player.FishingLevel > 4 && Game1.player.stats.Get("FishingTreasures") > 2 && Game1.random.NextDouble() < 0.02 + ((!Game1.player.mailReceived.Contains("roeBookDropped")) ? ((double)Game1.player.stats.Get("FishingTreasures") * 0.001) : 0.001))
 		{
 			treasures.Add(ItemRegistry.Create("(O)Book_Roe"));
 			Game1.player.mailReceived.Add("roeBookDropped");

--- a/Patches.cs
+++ b/Patches.cs
@@ -469,7 +469,8 @@ public class Patches
 
             inventory = inventory.Where(v => ModEntry.Config.PriceMin <= v.sellToStorePrice() / v.Stack && (v.sellToStorePrice() / v.Stack <= priceMax || priceMax <= -1)).ToList();
 
-            ItemGrabMenu itemMenu = new ItemGrabMenu(inventory, ItemGrabMenu.source_fishingChest).setEssential(true);
+            ItemGrabMenu itemMenu = new ItemGrabMenu(inventory).setEssential(true);
+            itemMenu.source = ItemGrabMenu.source_fishingChest;
             
             Game1.player.Money += prize;
             


### PR DESCRIPTION
A user posted on my Fishbot mod that it was unable to auto-loot treasure after I updated it to check the source of the ItemGrabMenu, such that it would no longer loot regular chests with the new "Always Enabled" function. After further investigation, it seems AdvancedFishingTreasure was the culprit.
It constructs a new ItemGrabMenu and provides the correct source as the second argument to the constructor, however that constructor actually takes a context object as its second argument. The correct way seems to be to set the source after.
Additionally, I was unable to build the project at first due to a direct use of Net-fields, rather than their capitalized property counterparts.
I assume both of these come from recent changes in Stardew Valley and SMAPI.

Finally, I'd like to encourage you to add an open source license to your mod, like the MIT or GPLv3, otherwise I technically don't have the legal right to provide a fixed build, and if you're absent in the future it would also make it impossible to provide an unofficial update.